### PR TITLE
Fixed FFMPEG call for Nuke 7

### DIFF
--- a/app.py
+++ b/app.py
@@ -173,7 +173,7 @@ class NukeQuickDailies(tank.platform.Application):
 
         elif sys.platform == "linux2":
             mov_out["file_type"].setValue("ffmpeg")
-            mov_out["codec"].setValue("MOV format (mov)")
+            mov_out["format"].setValue("MOV format (mov)")
 
         # turn on the nodes        
         mov_out.knob('disable').setValue(False)


### PR DESCRIPTION
Fixed syntax in FFMPEG call, which worked in Nuke 6.3 but not 7
