### PR TITLE
Zero Config Quickdailies [do not merge]

### DIFF
--- a/app.py
+++ b/app.py
@@ -108,9 +108,10 @@ class NukeQuickDailies(tank.platform.Application):
         # top-left says 
         # Project XYZ
         # Shot ABC
-        top_left = "%s\n%s %s" % (self.context.project["name"], 
-                                  self.context.entity["type"], 
-                                  self.context.entity["name"])
+        top_left = "%s" % self.context.project["name"]
+        if self.context.entity:
+            top_left += "\n%s %s" % (self.context.entity["type"], self.context.entity["name"])
+
         group_node.node("top_left_text")["message"].setValue(top_left)
         
         # top-right has date
@@ -124,7 +125,8 @@ class NukeQuickDailies(tank.platform.Application):
                 
         # and the slate
         slate_str = "Project: %s\n" % self.context.project["name"]
-        slate_str += "%s: %s\n" % (self.context.entity["type"], self.context.entity["name"])
+        if self.context.entity:
+            slate_str += "%s: %s\n" % (self.context.entity["type"], self.context.entity["name"])
         slate_str += "Name: %s\n" % sg_version_name
 
         if self.context.task:

--- a/app.py
+++ b/app.py
@@ -123,12 +123,10 @@ class NukeQuickDailies(tank.platform.Application):
         group_node.node("bottom_left_text")["message"].setValue(bottom_left)
                 
         # and the slate
-        slate_str =  "Project: %s\n" % self.context.project["name"]
+        slate_str = "Project: %s\n" % self.context.project["name"]
         slate_str += "%s: %s\n" % (self.context.entity["type"], self.context.entity["name"])
-        if name:
-            slate_str += "Name: %s\n" % name
-        slate_str += "Iteration: %d\n" % iteration
-        
+        slate_str += "Name: %s\n" % sg_version_name
+
         if self.context.task:
             slate_str += "Task: %s\n" % self.context.task["name"]
         elif self.context.step:
@@ -202,7 +200,7 @@ class NukeQuickDailies(tank.platform.Application):
         # now try to see if we are in a normal work file
         # in that case deduce the name from it
         current_scene_path = nuke.root().name()
-        if current_scene_path:
+        if current_scene_path and current_scene_path != "Root":
             current_scene_path = current_scene_path.replace("/", os.path.sep)
             # get just filename
             current_scene_name = os.path.basename(current_scene_path)
@@ -211,7 +209,7 @@ class NukeQuickDailies(tank.platform.Application):
             name = current_scene_name
 
         # append date and time
-        timestamp = datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+        timestamp = datetime.datetime.now().strftime("%d %b %Y %H:%M:%S")
         timestamp_filename = datetime.datetime.now().strftime("%Y%m%d_%H%M%S")
 
         sg_version_name = "%s %s" % (name, timestamp)

--- a/app.py
+++ b/app.py
@@ -21,12 +21,6 @@ import os
 import tempfile
 import datetime
 
-PNG_THUMB_SEQUENCE_MARKER = "%08d"
-
-
-
-
-
 class NukeQuickDailies(tank.platform.Application):
     
     def init_app(self):
@@ -37,11 +31,7 @@ class NukeQuickDailies(tank.platform.Application):
         # assign this app to nuke handle so that the node
         # callback finds it
         nuke.tk_nuke_quickdailies = self
-        
-        self._movie_template = self.get_template("movie_template")
-        self._snapshot_template = self.get_template("current_scene_template")
-        self._version_template = self.get_template("sg_version_name_template")
-        
+
         # add to tank menu
         icon = os.path.join(self.disk_location, "resources", "node_icon.png")
         self.engine.register_command("Shotgun Quick Dailies", 
@@ -70,9 +60,6 @@ class NukeQuickDailies(tank.platform.Application):
         :param old_context: The sgtk.context.Context being switched from.
         :param new_context: The sgtk.context.Context being switched to.
         """
-        self._movie_template = self.get_template("movie_template")
-        self._snapshot_template = self.get_template("current_scene_template")
-        self._version_template = self.get_template("sg_version_name_template")
 
     # callbacks! note that if the behaviour changes, we need to version up these methods
     # we must support all older versions of nodes that may remain inside of scenes.
@@ -89,7 +76,7 @@ class NukeQuickDailies(tank.platform.Application):
         """
         return int(nuke.root()["last_frame"].value())
 
-    def _setup_formatting(self, group_node, name, iteration):
+    def _setup_formatting(self, group_node, sg_version_name):
         """
         Sets up slates and burnins
         """
@@ -132,9 +119,7 @@ class NukeQuickDailies(tank.platform.Application):
         # bottom left says
         # Name#increment
         # User
-        bottom_left = "%s " % name.capitalize() if name else ""
-        bottom_left += ("Iteration %d\n" % (iteration))
-        bottom_left += user_name
+        bottom_left = "%s\n%s" % (sg_version_name, user_name)
         group_node.node("bottom_left_text")["message"].setValue(bottom_left)
                 
         # and the slate
@@ -155,24 +140,17 @@ class NukeQuickDailies(tank.platform.Application):
         
         group_node.node("slate_info")["message"].setValue(slate_str)
 
-
-
-    def _render(self, group_node, mov_path, png_path):
+    def _render(self, group_node, mov_path):
         """
         Renders quickdaily node
         """
 
         # setup quicktime output resolution
-        width = self.get_setting("width", 1024)
-        height = self.get_setting("height", 540)        
+        width = 1280
+        height = 720
         mov_reformat_node = group_node.node("mov_reformat")
         mov_reformat_node["box_width"].setValue(width)
         mov_reformat_node["box_height"].setValue(height)
-        
-        # setup output png path
-        png_out = group_node.node("png_writer")
-        png_path = png_path.replace(os.sep, "/")
-        png_out["file"].setValue(png_path)
         
         # setup output quicktime path
         mov_out = group_node.node("mov_writer")
@@ -186,21 +164,20 @@ class NukeQuickDailies(tank.platform.Application):
 
         # turn on the nodes        
         mov_out.knob('disable').setValue(False)
-        png_out.knob('disable').setValue(False)
 
         # finally render everything!
         # default to using the first view on stereo
         
         try:
             first_view = nuke.views()[0]        
-            nuke.executeMultiple( [mov_out, png_out], 
-                                  ([ self._get_first_frame()-1, self._get_last_frame(), 1 ],),
-                                  [first_view]
-                                  )
+            nuke.executeMultiple(
+                [mov_out],
+                ([ self._get_first_frame()-1, self._get_last_frame(), 1 ],),
+                [first_view]
+                )
         finally:            
             # turn off the nodes again
             mov_out.knob('disable').setValue(True)
-            png_out.knob('disable').setValue(True)
 
 
     def _get_comments(self, sg_version_name):
@@ -216,42 +193,6 @@ class NukeQuickDailies(tank.platform.Application):
         else:
             return None
 
-    def _produce_thumbnails(self, png_path):
-        """
-        Makes filmstrip thumbs and thumb.
-        Assumes that png_path has a PNG_THUMB_SEQUENCE_MARKER 
-        sequence indicator in the path (like %08d)
-        
-        returns (thumb_path, filmstrip_path)
-        """
-        start_frame = self._get_first_frame()
-        end_frame = self._get_last_frame()
-        
-        # first get static thumbnail
-        # middle frame is thumb
-        thumb_frame = (end_frame-start_frame) / 2 + start_frame
-        single_thumb_path = png_path.replace(PNG_THUMB_SEQUENCE_MARKER, PNG_THUMB_SEQUENCE_MARKER % thumb_frame)
-        if not os.path.exists(single_thumb_path):
-            single_thumb_path = None
-        
-        # now try to build film strip using the convert command
-        # convert img1.png img2.png img3.png +append output.png
-        filmstrip_thumb_path = tempfile.NamedTemporaryFile(suffix=".png", prefix="tankthumb", delete=False).name
-        
-        cmdline = ["convert"]
-        for x in range(start_frame, end_frame+1):
-            cmdline.append("\"%s\"" %  png_path.replace(PNG_THUMB_SEQUENCE_MARKER, PNG_THUMB_SEQUENCE_MARKER % x) )
-        cmdline.append("+append")
-        cmdline.append("\"%s\"" % filmstrip_thumb_path)
-        
-        cmd = " ".join(cmdline)
-        
-        if os.system(cmd) != 0:  
-            filmstrip_thumb_path = None
-        
-        return (single_thumb_path, filmstrip_thumb_path)
-        
-
     def create_daily_v1(self, group_node):
         """
         Create daily. Version 1 of implementation.
@@ -260,39 +201,23 @@ class NukeQuickDailies(tank.platform.Application):
         
         # now try to see if we are in a normal work file
         # in that case deduce the name from it
-        curr_filename = nuke.root().name().replace("/", os.path.sep)
-        version = 0
-        name = "Quickdaily"
-        if self._snapshot_template.validate(curr_filename):
-            fields = self._snapshot_template.get_fields(curr_filename)
-            name = fields.get("name")
-            version = fields.get("version")
+        current_scene_path = nuke.root().name()
+        if current_scene_path:
+            current_scene_path = current_scene_path.replace("/", os.path.sep)
+            # get just filename
+            current_scene_name = os.path.basename(current_scene_path)
+            # drop .nk
+            current_scene_name = os.path.splitext(current_scene_name)[0]
+            name = current_scene_name
 
-        # calculate the increment
-        fields = self.context.as_template_fields(self._movie_template)
-        if name:
-            fields["name"] = name
-        if version != None:
-            fields["version"] = version
-        fields["iteration"] = 1
-        
-        # get all files
-        files = self.tank.paths_from_template(self._movie_template, fields, ["iteration"])
-        
-        # get all iteration numbers
-        iterations = [self._movie_template.get_fields(f).get("iteration") for f in files]
-        if len(iterations) == 0:
-            new_iteration = 1
-        else:
-            new_iteration = max(iterations) + 1
-        
-        # compute new file path
-        fields["iteration"] = new_iteration
-        mov_path = self._movie_template.apply_fields(fields)
-        
-        # compute shotgun version name
-        sg_version_name = self._version_template.apply_fields(fields)
-        
+        # append date and time
+        timestamp = datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+        timestamp_filename = datetime.datetime.now().strftime("%Y%m%d_%H%M%S")
+
+        sg_version_name = "%s %s" % (name, timestamp)
+        quicktime_filename = "%s_%s" % (name, timestamp_filename)
+
+
         # get inputs
         message = self._get_comments(sg_version_name)
         if message is None:
@@ -300,21 +225,14 @@ class NukeQuickDailies(tank.platform.Application):
             return
         
         # set metadata
-        self._setup_formatting(group_node, name, new_iteration)
+        self._setup_formatting(group_node, sg_version_name)
         
-        # make sure folders exist for mov
-        mov_folder = os.path.dirname(mov_path)
-        self.ensure_folder_exists(mov_folder)
-        
-        # generate temp file for png sequence
-        png_tmp_folder = tempfile.mkdtemp()
-        png_path = os.path.join(png_tmp_folder, "thumb_seq.%s.png" % PNG_THUMB_SEQUENCE_MARKER)
+        # generate temp file for mov sequence
+        mov_folder = tempfile.mkdtemp()
+        mov_path = os.path.join(mov_folder, "%s.mov" % quicktime_filename)
         
         # and render!
-        self._render(group_node, mov_path, png_path)
-
-        # make thumbnails
-        (thumb, filmstrip) = self._produce_thumbnails(png_path)
+        self._render(group_node, mov_path)
 
         # create sg version        
         data = {
@@ -325,7 +243,6 @@ class NukeQuickDailies(tank.platform.Application):
             "sg_task": self.context.task,
             "created_by": tank.util.get_current_user(self.tank),
             "user": tank.util.get_current_user(self.tank),
-            "sg_path_to_movie": mov_path,
             "sg_first_frame": self._get_first_frame(),
             "sg_last_frame": self._get_last_frame(),
             "frame_count": (self._get_last_frame() - self._get_first_frame()) + 1,
@@ -333,23 +250,17 @@ class NukeQuickDailies(tank.platform.Application):
             "sg_movie_has_slate": True
         }
 
-        # thumbnails and filmstrip thumbnails can be added at creation time to save time
-        if thumb:
-            data["image"] = thumb
-        if filmstrip:
-            data["filmstrip_image"] = filmstrip
-
         entity = self.shotgun.create("Version", data)
         self.log_debug("Version created in ShotgunL %s" % entity)
         
         # upload the movie to Shotgun if desired
-        if self.get_setting("upload_movie", False):
-            self.log_debug("Uploading movie to Shotgun")
-            self.shotgun.upload("Version", entity["id"], mov_path, "sg_uploaded_movie")
+        self.log_debug("Uploading movie to Shotgun")
+        self.shotgun.upload("Version", entity["id"], mov_path, "sg_uploaded_movie")
 
         # execute post hook
+        self.log_debug("Running post hooks...")
         for h in self.get_setting("post_hooks", []):
-            self.execute_hook_by_name(h, mov_path=mov_path, version_id=entity["id"], comments=message)
+            self.execute_hook_by_name(h, shotgun_data=entity)
         
         # status message!
         sg_url = "%s/detail/Version/%s" % (self.shotgun.base_url, entity["id"]) 

--- a/info.yml
+++ b/info.yml
@@ -13,52 +13,14 @@
 # expected fields in the configuration file for this app
 configuration:
 
-    width:
-        type: int
-        description: The quicktime resolution width
-
-    height:
-        type: int
-        description: The quicktime resolution height
-        
-    movie_template:
-        type: template
-        fields: context, iteration, [name], [version]
-        description: The location where the output quicktime will be written to. The two fields
-                     iteration and optionally name will be populated. Iteration is an integer 
-                     number which will be automatically calculated based on the existing files 
-                     on disk. Name is typically derived from the name of the current scene.
-                     
-    current_scene_template:
-        type: template
-        fields: context, [name], [version], *
-        description: Template that will be used to extract the name and version from the current 
-                     scene. Both name and version are optional.
-                     
-    sg_version_name_template:
-        type: template
-        fields: context, iteration, [version], [name], *
-        description: "Template used to populate the version name in Shotgun. You can use any field 
-                     from the current context (such as for example Shot and Sequence) and the template
-                     must include iteration.  Additionally, name and the current version will be used 
-                     if they are defined."
-
-    upload_movie:
-        type: bool
-        description: If true, the Quicktime movie will be uploaded to Shotgun in the Version's 
-                     sg_uploaded_movie field which will allow the Version to be viewed in the 
-                     Shotgun web player.
-        default_value: true
-
     post_hooks:
         type: list
         allows_empty: true
         values:
             type: hook
-            parameters: [mov_path, version_id, comments] 
         description: List of hooks that runs after a quickdaily has been rendered and 
-                     uploaded to Shotgun. Parameters passed to the hook are 
-                     mov_path, version_id and comments.
+                     uploaded to Shotgun. Parameter passed to the hook is
+                     version_id.
 
     codec_settings_hook:
         type: hook


### PR DESCRIPTION
Backwards incompatible change - if we do release this, we  should consider pushing it out as `tk-nuke-quickdailies2`. This is a zero config version of quickdailies which uploads the version to shotgun and doesn't rely on templates. Settings are stripped down to a minimum and no local files on disk are created. Thumbnails and filmstrips are generated by the transcoder rather than locally.